### PR TITLE
Remove Big Decimal gem

### DIFF
--- a/coinbase-exchange.gemspec
+++ b/coinbase-exchange.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "bigdecimal"
   spec.add_dependency "faye-websocket"
   spec.add_dependency "em-http-request"
 

--- a/lib/coinbase/exchange.rb
+++ b/lib/coinbase/exchange.rb
@@ -1,4 +1,3 @@
-require "bigdecimal"
 require "json"
 require "uri"
 require "net/http"


### PR DESCRIPTION
Since this is built into ruby, no reason to fetch the Gem version.